### PR TITLE
SEO: Fix meta description tag and missing alt text

### DIFF
--- a/_layouts/footer.njk
+++ b/_layouts/footer.njk
@@ -22,7 +22,7 @@
             <use xlink:href="/img/symbol-defs.svg#icon-mail"></use>
           </svg>
         </a>
-        <img class="socials-icon seal" src="/img/seal/black.png">
+        <img class="socials-icon seal" src="/img/seal/black.png" alt="The Bakery recording studios">
       </div>
       <p>1710 Altamont Dr, Richmond, VA 23220</p>
     </div>

--- a/_layouts/page-base.njk
+++ b/_layouts/page-base.njk
@@ -18,6 +18,9 @@ title: The Bakery
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta
+    name="description"
+    content="Located in the vibrant Scotts Addition neighborhood of Richmond, Virginia, The Bakery Recording Studio is within minutes of everything the city of Richmond has to offer. The Bakery is the perfect location to record, regardless of the size of the project. The state of the art studios are equipped with two separate live/control rooms, and also offer other amenities to make your stay comfortable.">
   <link rel="stylesheet" href="/bundle.css">
   <link rel="shortcut icon" type="image" href="/img/favicon.png">
   <title>{{ title }}</title>


### PR DESCRIPTION
# Summary

Adds missing meta tag and missing alt text for footer bakery seal.

## Score improvement

- Before patch: 75
- After fix: **92**

## Related issue

#16 